### PR TITLE
Add HTML link parser with tests

### DIFF
--- a/Scraped Data/Scripts/afdb_scrape.py
+++ b/Scraped Data/Scripts/afdb_scrape.py
@@ -1,32 +1,56 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-import time
+"""Utility for scraping links from the AfDB projects page."""
 
-# Setup headless Chrome
-options = Options()
-options.add_argument("--headless")
-options.add_argument("--disable-gpu")
-options.add_argument("--no-sandbox")
-options.add_argument("window-size=1920x1080")
-options.add_argument("user-agent=Mozilla/5.0 ...")  # Optional
+from html.parser import HTMLParser
 
-driver = webdriver.Chrome(options=options)
 
-# Load the page
-driver.get("https://www.afdb.org/en/documents/projects-operations")
+class _LinkParser(HTMLParser):
+    """Simple HTML parser that collects href attributes."""
 
-# Let JavaScript load (Cloudflare check)
-time.sleep(10)  # Wait until Cloudflare passes
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
 
-# Extract page source
-html = driver.page_source
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str]]) -> None:
+        if tag == "a":
+            for name, value in attrs:
+                if name == "href":
+                    self.links.append(value)
 
-# (Optional) Pass to BeautifulSoup
-from bs4 import BeautifulSoup
-soup = BeautifulSoup(html, "html.parser")
 
-# Example: get all links
-for a in soup.find_all("a", href=True):
-    print(a["href"])
+def parse_links(html: str) -> list[str]:
+    """Parse HTML and return a list of href values for all anchor tags."""
+    parser = _LinkParser()
+    parser.feed(html)
+    return parser.links
 
-driver.quit()
+
+def scrape_afdb_links() -> list[str]:
+    """Use Selenium to fetch the AfDB projects page and return extracted links."""
+    # Import Selenium locally so parse_links can be imported without the dependency
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    import time
+
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("window-size=1920x1080")
+    options.add_argument("user-agent=Mozilla/5.0 ...")
+
+    driver = webdriver.Chrome(options=options)
+    try:
+        driver.get("https://www.afdb.org/en/documents/projects-operations")
+        # Wait a bit for potential JavaScript/Cloudflare checks
+        time.sleep(10)
+        html = driver.page_source
+    finally:
+        driver.quit()
+
+    return parse_links(html)
+
+
+if __name__ == "__main__":
+    for link in scrape_afdb_links():
+        print(link)
+

--- a/tests/test_afdb_scrape.py
+++ b/tests/test_afdb_scrape.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+# Load the module from its file location because the directory name contains a space
+module_path = Path(__file__).resolve().parents[1] / 'Scraped Data' / 'Scripts' / 'afdb_scrape.py'
+spec = importlib.util.spec_from_file_location('afdb_scrape', module_path)
+afdb_scrape = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(afdb_scrape)
+
+
+def test_parse_links_basic():
+    html = """
+    <html>
+        <body>
+            <a href=\"/doc1\">Document 1</a>
+            <a href=\"https://example.com/doc2\">Doc2</a>
+        </body>
+    </html>
+    """
+    assert afdb_scrape.parse_links(html) == ["/doc1", "https://example.com/doc2"]
+


### PR DESCRIPTION
## Summary
- refactor AfDB scraper to expose `parse_links` helper
- use builtin `html.parser` so the module imports without extra dependencies
- add test for `parse_links` with a sample HTML snippet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bfcc7bdf4833398b0db51013273ba